### PR TITLE
feat: add namecheap terraform provider implemented

### DIFF
--- a/apps/terraform/main.tf
+++ b/apps/terraform/main.tf
@@ -25,14 +25,25 @@ terraform {
     auth0 = {
       source = "auth0/auth0"
     }
+
+    namecheap = {
+      source  = "namecheap/namecheap"
+      version = ">= 2.1.0"
+    }
   }
+}
+
+provider namecheap {
+  api_key  = var.namecheap_api_key
+  username = var.namecheap_username
+  api_user = var.namecheap_username
 }
 
 provider "auth0" {
   domain        = var.auth0_domain
   client_id     = var.auth0_client_id
   client_secret = var.auth0_client_secret
-
+  debug         = true
 }
 
 provider "stripe" {

--- a/apps/terraform/variables.tf
+++ b/apps/terraform/variables.tf
@@ -4,6 +4,13 @@ variable "project_name" {
   default     = "tec2000"
 }
 
+variable "namecheap_username" {
+  type        = string
+  description = "The namecheap username"
+}
+
+variable "namecheap_api_key" {}
+
 variable "auth0_domain" {
   type        = string
   description = "Auth0 domain"


### PR DESCRIPTION
Objective:

- Add namecheap terraform provider
- Add terraform cloud environment secrets